### PR TITLE
Revert some auxiliary changes

### DIFF
--- a/eus-test.l
+++ b/eus-test.l
@@ -11,6 +11,7 @@
 (defun sym-class (type)
   (cond
     ((eql type 'list) cons)
+    ((memq type '(simple-string simple-base-string)) string)
     ((symbolp type) (symbol-value type))
     (t type)))
 

--- a/eus-test.l
+++ b/eus-test.l
@@ -84,7 +84,7 @@
      (defun ,name ()
        (assert  ,(if (single res)
 		     `(equal ,clause ',@res)
-		     `(equal ,clause (apply #'values ',res)))))
+		     `(equal (multiple-value-list ,clause) ',res))))
      (send *unit-test* :add-function ',name)
      ',name))
 


### PR DESCRIPTION
Revert some changes made in 5dff3140f14ea271af13ae80718710f2b9a29093 , since we can now also use `multiple-values` and `loop` in eus.

Also fixes some typos and indenting. 