### PR TITLE
Correc values bug

### DIFF
--- a/auxiliary/eus-multiple-values.l
+++ b/auxiliary/eus-multiple-values.l
@@ -27,7 +27,12 @@
   (if (or (and args (null (cdr args)))
           (not mv-interface::is-mv-on))
       (car args)
-      (cons mv-interface::magical args)))
+      (cons mv-interface::magical
+            (mapcar #'(lambda (arg)
+                     (if (mv-interface::magicalp arg)
+                         (cadr arg)
+                         arg))
+                 args))))
 
 (defun values-list (list)
   "All of the values of list are returned as multiple values"


### PR DESCRIPTION
```
3.eus$ (multiple-value-list (values (values 1 2) 3 (values (values 4 5) 6)))
(multiple-value-list (values (values 1 2) 3 (values (values 4 5) 6)))
(1 3 4)
```

```
➜  auxiliary git:(gsoc2018) ^[[?2004hsbcl
sbcl^[[?2004l
This is SBCL 1.3.1.debian, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
*  (multiple-value-list (values (values 1 2) 3 (values (values 4 5) 6)))
 (multiple-value-list (values (values 1 2) 3 (values (values 4 5) 6)))

(1 3 4)
```

this fix might not be the most efficient, though 