### PR TITLE
Added typecase ^ improved typep

### DIFF
--- a/auxiliary/eus-predicates.l
+++ b/auxiliary/eus-predicates.l
@@ -4,6 +4,23 @@
 (defmacro complement (fn)
   `(function (lambda (&rest args) (not (apply ,fn args)))))
 
+
+(defun typep (obj type)
+  "Returns T if OBJECT is of type TYPE."
+  (cond ((numberp obj)
+         (or
+          (eq type 'number)
+          (and (integerp obj) (eq type 'integer))
+          (and (integerp obj) (>= obj 0) (or
+                                          (eq type 'natural)
+                                          (eq type 'character))) 
+          (and (floatp obj) (eq type 'float))
+          (eq type 'ratio)))
+        ((consp obj) (or (eq type 'cons) (eq type 'list)))
+        (t
+         (and (boundp type)
+              (derivedp obj (symbol-value type))))))
+
 ;;; EQUALP -- public.
 ;;
 (defun equalp (x y)
@@ -77,4 +94,4 @@
 		    (return-from equalp nil))))))
 	(t nil)))
 
-(export '(complement equalp))
+(export '(complement equalp typep))

--- a/auxiliary/eus-types.l
+++ b/auxiliary/eus-types.l
@@ -1,6 +1,20 @@
 (in-package "LISP")
 
 
+
+(defmacro typecase (keyform &rest cases)
+  "TYPECASE Keyform {(Type Form*)}*
+  Evaluates the Forms in the first clause for which TYPEP of Keyform
+  and Type is true.  If a singleton key is T or Otherwise then the
+  clause is a default clause."
+  `(OOtypecase ,keyform (quote ,cases)))
+
+(defun OOtypecase (keyform cases)
+  (dolist (el cases)
+    (when (typep keyform (car el))
+      (return-from OOtypecase (eval (cadr el))))))
+
+
 (defun find-class (obj &optional error-p) (class obj))
 
 (defun sym-class (type)
@@ -10,7 +24,7 @@
     ((symbolp type) (symbol-value type))
     (t type)))
 
-(alias'=concatenate 'concatenate)
+(alias '=concatenate 'concatenate)
 (defun concatenate (type &rest args)
   (apply #'=concatenate (sym-class type) args))
 
@@ -30,4 +44,4 @@
 		     (t 'vector))))
     (apply #'=make-array dim :element-type elmt args)))
 
-(export '(find-class))
+(export '(find-class typecase))


### PR DESCRIPTION
the idea was to add the other casel-like macros as well (etypecase, ecase, etc.), and others, in the cmucl style.. but they ended depending on too many things, many of which not currently working